### PR TITLE
Avoid git actions on npm version, package version is all that's needed

### DIFF
--- a/assets/out
+++ b/assets/out
@@ -47,7 +47,7 @@ fi
 
 # optional version override though "params: {version: path/to/version/file}"
 [ -n "$version_string" ] \
-&& npm version "$version_string" \
+&& npm version --no-git-tag-version "$version_string" \
 || version_string=$(jq -r .version < package.json)
 
 echo "Publishing..."


### PR DESCRIPTION
As title says git versioning and npm versioning are currently separate tasks so this can be safely removed from the npm step of publishing a release